### PR TITLE
Adding the scala complier

### DIFF
--- a/morph-base/pom.xml
+++ b/morph-base/pom.xml
@@ -31,7 +31,25 @@
 			<version>0.1</version>
 		</dependency>
 
-	</dependencies>
+	</dependencies>	
+	
+	<build>
+        <plugins>
+            <plugin>
+                <groupId>org.scala-tools</groupId>
+               <artifactId>maven-scala-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>testCompile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+	
 
 	<distributionManagement>
 		<repository>

--- a/odemapster-core/pom.xml
+++ b/odemapster-core/pom.xml
@@ -37,11 +37,11 @@
 			<version>5.1.18</version>
 		</dependency>
 
-<!-- 		<dependency>
+ 		<dependency>
 			<groupId>es.upm.fi.dia.oeg.morph</groupId>
 			<artifactId>morph-base</artifactId>
 			<version>1.0-SNAPSHOT</version>
-		</dependency> -->
+		</dependency>
 
 		<dependency>
 			<groupId>zql</groupId>


### PR DESCRIPTION
morph-base artefact was empty because it didn't have the scala comelier. I also uncommented the morph-base dependency in the odemapster-core as the dependency is required to build odemapster-core with Maven.  
